### PR TITLE
Fix old exports

### DIFF
--- a/assertion-metadata.js
+++ b/assertion-metadata.js
@@ -1,11 +1,17 @@
-module.exports.getAssertionSizeInBytes = (assertion) => {
-    return Buffer.byteLength(JSON.stringify(assertion));
-};
+function getAssertionSizeInBytes(assertion) {
+  return Buffer.byteLength(JSON.stringify(assertion));
+}
 
-module.exports.getAssertionTriplesNumber = (assertion) => {
-    return assertion.length;
-};
+function getAssertionTriplesNumber(assertion) {
+  return assertion.length;
+}
 
-module.exports.getAssertionChunksNumber = (assertion) => {
-    return assertion.length;
+function getAssertionChunksNumber(assertion) {
+  return assertion.length;
+}
+
+module.exports = {
+  getAssertionSizeInBytes,
+  getAssertionTriplesNumber,
+  getAssertionChunksNumber,
 };

--- a/calculate-root.js
+++ b/calculate-root.js
@@ -2,11 +2,18 @@ const keccak256 = require("./keccak256.js");
 const ethers = require("ethers");
 const { MerkleTree } = require("merkletreejs");
 
-module.exports = calculateRoot = (assertion) => {
+function calculateRoot(assertion) {
   assertion.sort();
   const leaves = assertion.map((element, index) =>
-    keccak256(ethers.utils.solidityPack(["bytes32", "uint256"], [keccak256(element), index]))
+    keccak256(
+      ethers.utils.solidityPack(
+        ["bytes32", "uint256"],
+        [keccak256(element), index]
+      )
+    )
   );
   const tree = new MerkleTree(leaves, keccak256, { sortPairs: true });
   return `0x${tree.getRoot().toString("hex")}`;
-};
+}
+
+module.exports = calculateRoot;

--- a/format-assertion.js
+++ b/format-assertion.js
@@ -3,7 +3,7 @@ const jsonld = require("jsonld");
 const ALGORITHM = "URDNA2015";
 const FORMAT = "application/n-quads";
 
-module.exports = formatAssertion = async (json, inputFormat) => {
+async function formatAssertion(json, inputFormat) {
   const options = {
     algorithm: ALGORITHM,
     format: FORMAT,
@@ -12,8 +12,8 @@ module.exports = formatAssertion = async (json, inputFormat) => {
   if (inputFormat) {
     options.inputFormat = inputFormat;
   }
-  const canonizedJson = await jsonld.canonize(json, options);
 
+  const canonizedJson = await jsonld.canonize(json, options);
   const assertion = canonizedJson.split("\n").filter((x) => x !== "");
 
   if (assertion && assertion.length === 0) {
@@ -21,4 +21,6 @@ module.exports = formatAssertion = async (json, inputFormat) => {
   }
 
   return assertion;
-};
+}
+
+module.exports = formatAssertion;

--- a/get-merkle-proof.js
+++ b/get-merkle-proof.js
@@ -1,15 +1,15 @@
 const ethers = require("ethers");
-const keccak256 = require("./keccak256.js")
+const keccak256 = require("./keccak256.js");
 const { MerkleTree } = require("merkletreejs");
 
-module.exports = getMerkleProof = (nquadsArray, challenge) => {
+function getMerkleProof(nquadsArray, challenge) {
   nquadsArray.sort();
 
   const leaves = nquadsArray.map((element, index) =>
     keccak256(
       ethers.utils.solidityPack(
         ["bytes32", "uint256"],
-        [keccak256(element), index],
+        [keccak256(element), index]
       )
     )
   );
@@ -19,4 +19,6 @@ module.exports = getMerkleProof = (nquadsArray, challenge) => {
     leaf: keccak256(nquadsArray[challenge]),
     proof: tree.getHexProof(leaves[challenge]),
   };
-};
+}
+
+module.exports = getMerkleProof;

--- a/keccak256.js
+++ b/keccak256.js
@@ -1,9 +1,11 @@
 const ethers = require("ethers");
 
-module.exports = keccak256 = (data) => {
-    let bytesLikeData = data;
-    if (!ethers.utils.isBytesLike(data)) {
-        bytesLikeData = ethers.utils.toUtf8Bytes(data);
-    }
-    return ethers.utils.keccak256(bytesLikeData);
+const keccak256 = (data) => {
+  let bytesLikeData = data;
+  if (!ethers.utils.isBytesLike(data)) {
+    bytesLikeData = ethers.utils.toUtf8Bytes(data);
+  }
+  return ethers.utils.keccak256(bytesLikeData);
 };
+
+module.exports = keccak256;

--- a/peer-id-2-hash.js
+++ b/peer-id-2-hash.js
@@ -1,7 +1,7 @@
 const ethers = require("ethers");
 
-module.exports = peerId2Hash = async (peerId) => {
-  return ethers.utils.sha256(
-    ethers.utils.toUtf8Bytes(peerId)
-  );
-};
+async function peerId2Hash(peerId) {
+  return ethers.utils.sha256(ethers.utils.toUtf8Bytes(peerId));
+}
+
+module.exports = peerId2Hash;


### PR DESCRIPTION
Fix old format of exports which caused issues with Next JS 13 while importing dkg.js
Issue to be fixed: https://github.com/OriginTrail/dkg.js/issues/79

Tested by changing node_modules in a dkg.js repo, running a demo/examples.js, and also by doing the same thing in a NextJS project, and calling dkg.js operations in a server component/next js route