### PR TITLE
fix get assertion size for browsers

### DIFF
--- a/assertion-metadata.js
+++ b/assertion-metadata.js
@@ -1,5 +1,8 @@
 function getAssertionSizeInBytes(assertion) {
-  return Buffer.byteLength(JSON.stringify(assertion));
+  const jsonString = JSON.stringify(assertion);
+  const encoder = new TextEncoder();
+  const encodedBytes = encoder.encode(jsonString);
+  return encodedBytes.length;
 }
 
 function getAssertionTriplesNumber(assertion) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "assertion-tools",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "assertion-tools",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "ISC",
       "dependencies": {
         "ethers": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assertion-tools",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Common assertion tools used in ot-node and dkg.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Replace Buffer which can only be run on server side Node.js code with a solution that can run on the client too but produces same results