### PR TITLE
[V8] Fix esm/cjs compatibility

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -1,0 +1,444 @@
+'use strict';
+
+var jsonld = require('jsonld');
+var ethers = require('ethers');
+var uuid = require('uuid');
+var merkletreejs = require('merkletreejs');
+var N3 = require('n3');
+
+const DEFAULT_CANON_ALGORITHM = 'URDNA2015';
+
+const DEFAULT_RDF_FORMAT = 'application/n-quads';
+
+const PRIVATE_ASSERTION_PREDICATE = 'https://ontology.origintrail.io/dkg/1.0#privateAssertionID';
+
+function arraifyKeccak256(data) {
+  let bytesLikeData = data;
+  if (!ethers.utils.isBytesLike(data)) {
+    bytesLikeData = ethers.utils.toUtf8Bytes(data);
+  }
+  return ethers.utils.keccak256(bytesLikeData);
+}
+
+async function formatAssertion(json, inputFormat) {
+  const options = {
+    algorithm: DEFAULT_CANON_ALGORITHM,
+    format: DEFAULT_RDF_FORMAT,
+  };
+
+  if (inputFormat) {
+    options.inputFormat = inputFormat;
+  }
+
+  const canonizedJson = await jsonld.canonize(json, options);
+  const assertion = canonizedJson.split("\n").filter((x) => x !== "");
+
+  if (assertion && assertion.length === 0) {
+    throw Error("File format is corrupted, no n-quads are extracted.");
+  }
+
+  return assertion;
+}
+
+function getAssertionSizeInBytes(assertion) {
+  const jsonString = JSON.stringify(assertion);
+  const encoder = new TextEncoder();
+  const encodedBytes = encoder.encode(jsonString);
+  return encodedBytes.length;
+}
+
+function getAssertionTriplesNumber(assertion) {
+  return assertion.length;
+}
+
+function getAssertionChunksNumber(assertion) {
+  return assertion.length;
+}
+
+async function calculateRoot(assertion) {
+  assertion.sort();
+  const leaves = assertion.map((element, index) =>
+    arraifyKeccak256(
+      ethers.utils.solidityPack(
+        ["bytes32", "uint256"],
+        [arraifyKeccak256(element), index]
+      )
+    )
+  );
+  const tree = new merkletreejs.MerkleTree(leaves, arraifyKeccak256, { sortPairs: true });
+  return `0x${tree.getRoot().toString("hex")}`;
+}
+
+function getMerkleProof(nquadsArray, challenge) {
+  nquadsArray.sort();
+
+  const leaves = nquadsArray.map((element, index) =>
+    arraifyKeccak256(
+      ethers.utils.solidityPack(
+        ["bytes32", "uint256"],
+        [arraifyKeccak256(element), index]
+      )
+    )
+  );
+  const tree = new merkletreejs.MerkleTree(leaves, arraifyKeccak256, { sortPairs: true });
+
+  return {
+    leaf: arraifyKeccak256(nquadsArray[challenge]),
+    proof: tree.getHexProof(leaves[challenge]),
+  };
+}
+
+function isEmptyObject$1(obj) {
+  return Object.keys(obj).length === 0 && obj.constructor === Object;
+}
+
+async function formatGraph(content) {
+  let privateAssertion;
+  if (content.private && !isEmptyObject$1(content.private)) {
+    privateAssertion = await formatAssertion(content.private);
+  }
+  const publicGraph = {
+    "@graph": [
+      content.public && !isEmptyObject$1(content.public) ? content.public : null,
+      content.private && !isEmptyObject$1(content.private)
+        ? {
+            [PRIVATE_ASSERTION_PREDICATE]: privateAssertion
+              ? calculateRoot(privateAssertion)
+              : null,
+          }
+        : null,
+    ],
+  };
+  const publicAssertion = await formatAssertion(publicGraph);
+
+  const result = {
+    public: publicAssertion,
+  };
+
+  if (privateAssertion) {
+    result.private = privateAssertion;
+  }
+
+  return result;
+}
+
+function generateNamedNode() {
+  return `uuid:${uuid.v4()}`;
+}
+
+var knowledgeAssetTools = /*#__PURE__*/Object.freeze({
+  __proto__: null,
+  calculateRoot: calculateRoot,
+  formatAssertion: formatAssertion,
+  formatGraph: formatGraph,
+  generateNamedNode: generateNamedNode,
+  getAssertionChunksNumber: getAssertionChunksNumber,
+  getAssertionSizeInBytes: getAssertionSizeInBytes,
+  getAssertionTriplesNumber: getAssertionTriplesNumber,
+  getMerkleProof: getMerkleProof
+});
+
+async function formatDataset(
+  json,
+  inputFormat,
+  outputFormat = DEFAULT_RDF_FORMAT,
+  algorithm = DEFAULT_CANON_ALGORITHM
+) {
+  const options = {
+    algorithm,
+    format: outputFormat,
+  };
+
+  if (inputFormat) {
+    options.inputFormat = inputFormat;
+  }
+
+  let privateAssertion;
+  if (json.private && !isEmptyObject(json.private)) {
+    const privateCanonizedJson = await jsonld.canonize(json.private, options);
+    privateAssertion = privateCanonizedJson.split("\n").filter((x) => x !== "");
+  } else if (!json.public) {
+    json = { public: json };
+  }
+  const publicCanonizedJson = await jsonld.canonize(json.public, options);
+  const publicAssertion = publicCanonizedJson
+    .split("\n")
+    .filter((x) => x !== "");
+
+  if (
+    publicAssertion &&
+    publicAssertion.length === 0 &&
+    privateAssertion &&
+    privateAssertion?.length === 0
+  ) {
+    throw Error("File format is corrupted, no n-quads are extracted.");
+  }
+  const dataset = { public: publicAssertion };
+  if (privateAssertion) {
+    dataset.private = privateAssertion;
+  }
+
+  return dataset;
+}
+
+function calculateByteSize(string) {
+  if (typeof string !== "string") {
+    throw Error(`Size can only be calculated for the 'string' objects.`);
+  }
+
+  const encoder = new TextEncoder();
+  const encodedBytes = encoder.encode(string);
+  return encodedBytes.length;
+}
+
+function calculateNumberOfChunks(quads, chunkSizeBytes = 32) {
+  const encoder = new TextEncoder();
+  const concatenatedQuads = quads.join("\n");
+  const totalSizeBytes = encoder.encode(concatenatedQuads).length;
+  return Math.ceil(totalSizeBytes / chunkSizeBytes);
+}
+
+function splitIntoChunks(quads, chunkSizeBytes = 32) {
+  const encoder = new TextEncoder();
+
+  const concatenatedQuads = quads.join("\n");
+  const encodedBytes = encoder.encode(concatenatedQuads);
+
+  const chunks = [];
+  let start = 0;
+
+  while (start < encodedBytes.length) {
+    const end = Math.min(start + chunkSizeBytes, encodedBytes.length);
+    const chunk = encodedBytes.slice(start, end);
+    chunks.push(Buffer.from(chunk).toString("utf-8"));
+    start = end;
+  }
+
+  return chunks;
+}
+
+function calculateMerkleRoot(quads, chunkSizeBytes = 32) {
+  const chunks = splitIntoChunks(quads, chunkSizeBytes);
+  let leaves = chunks.map((chunk, index) =>
+    Buffer.from(
+      ethers.utils
+        .solidityKeccak256(["string", "uint256"], [chunk, index])
+        .replace("0x", ""),
+      "hex"
+    )
+  );
+
+  while (leaves.length > 1) {
+    const nextLevel = [];
+
+    for (let i = 0; i < leaves.length; i += 2) {
+      const left = leaves[i];
+
+      if (i + 1 >= leaves.length) {
+        nextLevel.push(left);
+        break;
+      }
+      const right = leaves[i + 1];
+
+      const combined = [left, right];
+      combined.sort(Buffer.compare);
+
+      const hash = Buffer.from(
+        ethers.utils.keccak256(Buffer.concat(combined)).replace("0x", ""),
+        "hex"
+      );
+
+      nextLevel.push(hash);
+    }
+
+    leaves = nextLevel;
+  }
+
+  return `0x${leaves[0].toString("hex")}`;
+}
+
+function calculateMerkleProof(quads, chunkSizeBytes, challenge) {
+  const chunks = splitIntoChunks(quads, chunkSizeBytes);
+  const leaves = chunks.map((chunk, index) =>
+    Buffer.from(
+      ethers.utils
+        .solidityKeccak256(["string", "uint256"], [chunk, index])
+        .replace("0x", ""),
+      "hex"
+    )
+  );
+
+  const tree = new merkletreejs.MerkleTree(leaves, arraifyKeccak256, { sortPairs: true });
+
+  return {
+    leaf: arraifyKeccak256(chunks[challenge]),
+    proof: tree.getHexProof(leaves[challenge]),
+  };
+}
+
+function groupNquadsBySubject(nquadsArray, sort = false) {
+  const parser = new N3.Parser({ format: "star" });
+  const grouped = {};
+
+  parser.parse(nquadsArray.join("")).forEach((quad) => {
+    const { subject, predicate, object } = quad;
+
+    let subjectKey;
+    if (subject.termType === "Quad") {
+      const nestedSubject = subject.subject.value;
+      const nestedPredicate = subject.predicate.value;
+      const nestedObject =
+        subject.object.termType === "Literal"
+          ? `"${subject.object.value}"`
+          : `<${subject.object.value}>`;
+      subjectKey = `<<<${nestedSubject}> <${nestedPredicate}> ${nestedObject}>>`;
+    } else {
+      subjectKey = `<${subject.value}>`;
+    }
+
+    if (!grouped[subjectKey]) {
+      grouped[subjectKey] = [];
+    }
+
+    const objectValue =
+      object.termType === "Literal" ? `"${object.value}"` : `<${object.value}>`;
+
+    const quadString = `${subjectKey} <${predicate.value}> ${objectValue} .`;
+    grouped[subjectKey].push(quadString);
+  });
+
+  let groupedValues = Object.entries(grouped);
+
+  if (sort) {
+    groupedValues = groupedValues.sort(([keyA], [keyB]) =>
+      keyA.localeCompare(keyB)
+    );
+  }
+
+  return groupedValues.map(([, quads]) => quads);
+}
+
+function countDistinctSubjects(nquadsArray) {
+  const parser = new N3.Parser({ format: "star" });
+  const subjects = new Set();
+
+  parser
+    .parse(nquadsArray.join(""))
+    .forEach((quad) => subjects.add(quad.subject.value));
+
+  return subjects.size;
+}
+
+function filterTriplesByAnnotation(
+  nquadsArray,
+  annotationPredicate = null,
+  annotationValue = null,
+  filterNested = true
+) {
+  const parser = new N3.Parser({ format: "star" });
+  const filteredTriples = [];
+
+  parser.parse(nquadsArray.join("")).forEach((quad) => {
+    const { subject, predicate, object } = quad;
+
+    const isNested = subject.termType === "Quad";
+
+    if (filterNested && isNested) {
+      const nestedSubject = subject.subject.value;
+      const nestedPredicate = subject.predicate.value;
+      const nestedObject =
+        subject.object.termType === "Literal"
+          ? `"${subject.object.value}"`
+          : `<${subject.object.value}>`;
+
+      const matches =
+        (!annotationPredicate || predicate.value === annotationPredicate) &&
+        (!annotationValue || object.value === annotationValue);
+
+      if (matches) {
+        filteredTriples.push(
+          `<${nestedSubject}> <${nestedPredicate}> ${nestedObject}`
+        );
+      }
+    } else if (!filterNested && !isNested) {
+      const subjectValue = `<${subject.value}>`;
+      const objectValue =
+        object.termType === "Literal"
+          ? `"${object.value}"`
+          : `<${object.value}>`;
+
+      const matches =
+        (!annotationPredicate || predicate.value === annotationPredicate) &&
+        (!annotationValue || object.value === annotationValue);
+
+      if (matches) {
+        filteredTriples.push(
+          `${subjectValue} <${predicate.value}> ${objectValue} .`
+        );
+      }
+    }
+  });
+
+  return filteredTriples;
+}
+
+function generateMissingIdsForBlankNodes(nquadsArray) {
+  const parser = new N3.Parser({ format: "star" });
+  const writer = new N3.Writer({ format: "star" });
+  const generatedIds = {};
+
+  // Function to replace blank nodes in quads and nested RDF-star triples
+  function replaceBlankNode(term) {
+    if (term.termType === "BlankNode") {
+      if (!generatedIds[term.value]) {
+        generatedIds[term.value] = `uuid:${uuid.v4()}`;
+      }
+      return N3.DataFactory.namedNode(generatedIds[term.value]);
+    }
+
+    if (term.termType === "Quad") {
+      // Recursively handle nested RDF-star triples
+      return N3.DataFactory.quad(
+        replaceBlankNode(term.subject),
+        replaceBlankNode(term.predicate),
+        replaceBlankNode(term.object)
+      );
+    }
+    return term; // Return IRI or Literal unchanged
+  }
+
+  const updatedNquads = parser.parse(nquadsArray.join("")).map((quad) => {
+    // Replace blank nodes in the quad
+    const updatedQuad = N3.DataFactory.quad(
+      replaceBlankNode(quad.subject),
+      replaceBlankNode(quad.predicate),
+      replaceBlankNode(quad.object)
+    );
+
+    // Convert back to string format
+    return updatedQuad;
+  });
+
+  return writer.quadsToString(updatedNquads).trimEnd().split("\n");
+}
+
+function isEmptyObject(obj) {
+  return Object.keys(obj).length === 0 && obj.constructor === Object;
+}
+
+var knowledgeCollectionTools = /*#__PURE__*/Object.freeze({
+  __proto__: null,
+  calculateByteSize: calculateByteSize,
+  calculateMerkleProof: calculateMerkleProof,
+  calculateMerkleRoot: calculateMerkleRoot,
+  calculateNumberOfChunks: calculateNumberOfChunks,
+  countDistinctSubjects: countDistinctSubjects,
+  filterTriplesByAnnotation: filterTriplesByAnnotation,
+  formatDataset: formatDataset,
+  generateMissingIdsForBlankNodes: generateMissingIdsForBlankNodes,
+  groupNquadsBySubject: groupNquadsBySubject,
+  splitIntoChunks: splitIntoChunks
+});
+
+exports.kaTools = knowledgeAssetTools;
+exports.kcTools = knowledgeCollectionTools;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "assertion-tools",
       "version": "8.0.0-gamma.1",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "ethers": "^5.7.2",
@@ -24,6 +25,7 @@
         "mocha": "^10.2.0",
         "nyc": "^15.1.0",
         "prettier": "^3.0.3",
+        "rollup": "^4.28.1",
         "sinon": "^16.0.0"
       }
     },
@@ -1570,6 +1572,272 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.28.1.tgz",
+      "integrity": "sha512-2aZp8AES04KI2dy3Ss6/MDjXbwBzj+i0GqKtWXgw2/Ma6E4jJvujryO6gJAghIRVz7Vwr9Gtl/8na3nDUKpraQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.28.1.tgz",
+      "integrity": "sha512-EbkK285O+1YMrg57xVA+Dp0tDBRB93/BZKph9XhMjezf6F4TpYjaUSuPt5J0fZXlSag0LmZAsTmdGGqPp4pQFA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.28.1.tgz",
+      "integrity": "sha512-prduvrMKU6NzMq6nxzQw445zXgaDBbMQvmKSJaxpaZ5R1QDM8w+eGxo6Y/jhT/cLoCvnZI42oEqf9KQNYz1fqQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.28.1.tgz",
+      "integrity": "sha512-WsvbOunsUk0wccO/TV4o7IKgloJ942hVFK1CLatwv6TJspcCZb9umQkPdvB7FihmdxgaKR5JyxDjWpCOp4uZlQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.28.1.tgz",
+      "integrity": "sha512-HTDPdY1caUcU4qK23FeeGxCdJF64cKkqajU0iBnTVxS8F7H/7BewvYoG+va1KPSL63kQ1PGNyiwKOfReavzvNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.28.1.tgz",
+      "integrity": "sha512-m/uYasxkUevcFTeRSM9TeLyPe2QDuqtjkeoTpP9SW0XxUWfcYrGDMkO/m2tTw+4NMAF9P2fU3Mw4ahNvo7QmsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.28.1.tgz",
+      "integrity": "sha512-QAg11ZIt6mcmzpNE6JZBpKfJaKkqTm1A9+y9O+frdZJEuhQxiugM05gnCWiANHj4RmbgeVJpTdmKRmH/a+0QbA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.28.1.tgz",
+      "integrity": "sha512-dRP9PEBfolq1dmMcFqbEPSd9VlRuVWEGSmbxVEfiq2cs2jlZAl0YNxFzAQS2OrQmsLBLAATDMb3Z6MFv5vOcXg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.28.1.tgz",
+      "integrity": "sha512-uGr8khxO+CKT4XU8ZUH1TTEUtlktK6Kgtv0+6bIFSeiSlnGJHG1tSFSjm41uQ9sAO/5ULx9mWOz70jYLyv1QkA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.28.1.tgz",
+      "integrity": "sha512-QF54q8MYGAqMLrX2t7tNpi01nvq5RI59UBNx+3+37zoKX5KViPo/gk2QLhsuqok05sSCRluj0D00LzCwBikb0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.28.1.tgz",
+      "integrity": "sha512-vPul4uodvWvLhRco2w0GcyZcdyBfpfDRgNKU+p35AWEbJ/HPs1tOUrkSueVbBS0RQHAf/A+nNtDpvw95PeVKOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.28.1.tgz",
+      "integrity": "sha512-pTnTdBuC2+pt1Rmm2SV7JWRqzhYpEILML4PKODqLz+C7Ou2apEV52h19CR7es+u04KlqplggmN9sqZlekg3R1A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.28.1.tgz",
+      "integrity": "sha512-vWXy1Nfg7TPBSuAncfInmAI/WZDd5vOklyLJDdIRKABcZWojNDY0NJwruY2AcnCLnRJKSaBgf/GiJfauu8cQZA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.28.1.tgz",
+      "integrity": "sha512-/yqC2Y53oZjb0yz8PVuGOQQNOTwxcizudunl/tFs1aLvObTclTwZ0JhXF2XcPT/zuaymemCDSuuUPXJJyqeDOg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.28.1.tgz",
+      "integrity": "sha512-fzgeABz7rrAlKYB0y2kSEiURrI0691CSL0+KXwKwhxvj92VULEDQLpBYLHpF49MSiPG4sq5CK3qHMnb9tlCjBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.28.1.tgz",
+      "integrity": "sha512-xQTDVzSGiMlSshpJCtudbWyRfLaNiVPXt1WgdWTwWz9n0U12cI2ZVtWe/Jgwyv/6wjL7b66uu61Vg0POWVfz4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.28.1.tgz",
+      "integrity": "sha512-wSXmDRVupJstFP7elGMgv+2HqXelQhuNf+IS4V+nUpNVi/GUiBgDmfwD0UGN3pcAnWsgKG3I52wMOBnk1VHr/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.28.1.tgz",
+      "integrity": "sha512-ZkyTJ/9vkgrE/Rk9vhMXhf8l9D+eAhbAVbsGsXKy2ohmJaWg0LPQLnIxRdRp/bKyr8tXuPlXhIoGlEB5XpJnGA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.28.1.tgz",
+      "integrity": "sha512-ZvK2jBafvttJjoIdKm/Q/Bh7IJ1Ose9IBOwpOXcOvW3ikGTQGmKDgxTC6oCAzW6PynbkKP8+um1du81XJHZ0JA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
@@ -1621,6 +1889,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -6149,6 +6424,45 @@
         "rlp": "bin/rlp"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.28.1.tgz",
+      "integrity": "sha512-61fXYl/qNVinKmGSTHAZ6Yy8I3YIJC/r2m9feHo6SwVAVcLT5MPwOUFe7EuURA/4m0NR8lXG4BBXuo/IZEsjMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.6"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.28.1",
+        "@rollup/rollup-android-arm64": "4.28.1",
+        "@rollup/rollup-darwin-arm64": "4.28.1",
+        "@rollup/rollup-darwin-x64": "4.28.1",
+        "@rollup/rollup-freebsd-arm64": "4.28.1",
+        "@rollup/rollup-freebsd-x64": "4.28.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.28.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.28.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.28.1",
+        "@rollup/rollup-linux-arm64-musl": "4.28.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.28.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.28.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.28.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.28.1",
+        "@rollup/rollup-linux-x64-gnu": "4.28.1",
+        "@rollup/rollup-linux-x64-musl": "4.28.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.28.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.28.1",
+        "@rollup/rollup-win32-x64-msvc": "4.28.1",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8141,6 +8455,139 @@
         "fastq": "^1.6.0"
       }
     },
+    "@rollup/rollup-android-arm-eabi": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.28.1.tgz",
+      "integrity": "sha512-2aZp8AES04KI2dy3Ss6/MDjXbwBzj+i0GqKtWXgw2/Ma6E4jJvujryO6gJAghIRVz7Vwr9Gtl/8na3nDUKpraQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-android-arm64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.28.1.tgz",
+      "integrity": "sha512-EbkK285O+1YMrg57xVA+Dp0tDBRB93/BZKph9XhMjezf6F4TpYjaUSuPt5J0fZXlSag0LmZAsTmdGGqPp4pQFA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-darwin-arm64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.28.1.tgz",
+      "integrity": "sha512-prduvrMKU6NzMq6nxzQw445zXgaDBbMQvmKSJaxpaZ5R1QDM8w+eGxo6Y/jhT/cLoCvnZI42oEqf9KQNYz1fqQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-darwin-x64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.28.1.tgz",
+      "integrity": "sha512-WsvbOunsUk0wccO/TV4o7IKgloJ942hVFK1CLatwv6TJspcCZb9umQkPdvB7FihmdxgaKR5JyxDjWpCOp4uZlQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-freebsd-arm64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.28.1.tgz",
+      "integrity": "sha512-HTDPdY1caUcU4qK23FeeGxCdJF64cKkqajU0iBnTVxS8F7H/7BewvYoG+va1KPSL63kQ1PGNyiwKOfReavzvNA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-freebsd-x64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.28.1.tgz",
+      "integrity": "sha512-m/uYasxkUevcFTeRSM9TeLyPe2QDuqtjkeoTpP9SW0XxUWfcYrGDMkO/m2tTw+4NMAF9P2fU3Mw4ahNvo7QmsQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.28.1.tgz",
+      "integrity": "sha512-QAg11ZIt6mcmzpNE6JZBpKfJaKkqTm1A9+y9O+frdZJEuhQxiugM05gnCWiANHj4RmbgeVJpTdmKRmH/a+0QbA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.28.1.tgz",
+      "integrity": "sha512-dRP9PEBfolq1dmMcFqbEPSd9VlRuVWEGSmbxVEfiq2cs2jlZAl0YNxFzAQS2OrQmsLBLAATDMb3Z6MFv5vOcXg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.28.1.tgz",
+      "integrity": "sha512-uGr8khxO+CKT4XU8ZUH1TTEUtlktK6Kgtv0+6bIFSeiSlnGJHG1tSFSjm41uQ9sAO/5ULx9mWOz70jYLyv1QkA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm64-musl": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.28.1.tgz",
+      "integrity": "sha512-QF54q8MYGAqMLrX2t7tNpi01nvq5RI59UBNx+3+37zoKX5KViPo/gk2QLhsuqok05sSCRluj0D00LzCwBikb0A==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.28.1.tgz",
+      "integrity": "sha512-vPul4uodvWvLhRco2w0GcyZcdyBfpfDRgNKU+p35AWEbJ/HPs1tOUrkSueVbBS0RQHAf/A+nNtDpvw95PeVKOA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.28.1.tgz",
+      "integrity": "sha512-pTnTdBuC2+pt1Rmm2SV7JWRqzhYpEILML4PKODqLz+C7Ou2apEV52h19CR7es+u04KlqplggmN9sqZlekg3R1A==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.28.1.tgz",
+      "integrity": "sha512-vWXy1Nfg7TPBSuAncfInmAI/WZDd5vOklyLJDdIRKABcZWojNDY0NJwruY2AcnCLnRJKSaBgf/GiJfauu8cQZA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.28.1.tgz",
+      "integrity": "sha512-/yqC2Y53oZjb0yz8PVuGOQQNOTwxcizudunl/tFs1aLvObTclTwZ0JhXF2XcPT/zuaymemCDSuuUPXJJyqeDOg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-x64-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.28.1.tgz",
+      "integrity": "sha512-fzgeABz7rrAlKYB0y2kSEiURrI0691CSL0+KXwKwhxvj92VULEDQLpBYLHpF49MSiPG4sq5CK3qHMnb9tlCjBw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-x64-musl": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.28.1.tgz",
+      "integrity": "sha512-xQTDVzSGiMlSshpJCtudbWyRfLaNiVPXt1WgdWTwWz9n0U12cI2ZVtWe/Jgwyv/6wjL7b66uu61Vg0POWVfz4g==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.28.1.tgz",
+      "integrity": "sha512-wSXmDRVupJstFP7elGMgv+2HqXelQhuNf+IS4V+nUpNVi/GUiBgDmfwD0UGN3pcAnWsgKG3I52wMOBnk1VHr/A==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.28.1.tgz",
+      "integrity": "sha512-ZkyTJ/9vkgrE/Rk9vhMXhf8l9D+eAhbAVbsGsXKy2ohmJaWg0LPQLnIxRdRp/bKyr8tXuPlXhIoGlEB5XpJnGA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-x64-msvc": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.28.1.tgz",
+      "integrity": "sha512-ZvK2jBafvttJjoIdKm/Q/Bh7IJ1Ose9IBOwpOXcOvW3ikGTQGmKDgxTC6oCAzW6PynbkKP8+um1du81XJHZ0JA==",
+      "dev": true,
+      "optional": true
+    },
     "@sinonjs/commons": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
@@ -8194,6 +8641,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -11589,6 +12042,35 @@
       "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
       "requires": {
         "bn.js": "^5.2.0"
+      }
+    },
+    "rollup": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.28.1.tgz",
+      "integrity": "sha512-61fXYl/qNVinKmGSTHAZ6Yy8I3YIJC/r2m9feHo6SwVAVcLT5MPwOUFe7EuURA/4m0NR8lXG4BBXuo/IZEsjMg==",
+      "dev": true,
+      "requires": {
+        "@rollup/rollup-android-arm-eabi": "4.28.1",
+        "@rollup/rollup-android-arm64": "4.28.1",
+        "@rollup/rollup-darwin-arm64": "4.28.1",
+        "@rollup/rollup-darwin-x64": "4.28.1",
+        "@rollup/rollup-freebsd-arm64": "4.28.1",
+        "@rollup/rollup-freebsd-x64": "4.28.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.28.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.28.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.28.1",
+        "@rollup/rollup-linux-arm64-musl": "4.28.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.28.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.28.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.28.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.28.1",
+        "@rollup/rollup-linux-x64-gnu": "4.28.1",
+        "@rollup/rollup-linux-x64-musl": "4.28.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.28.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.28.1",
+        "@rollup/rollup-win32-x64-msvc": "4.28.1",
+        "@types/estree": "1.0.6",
+        "fsevents": "~2.3.2"
       }
     },
     "run-parallel": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,14 @@
   "description": "Common assertion tools used in ot-node and dkg.js",
   "main": "index.js",
   "type": "module",
+  "exports": {
+    "import": "./index.js",
+    "require": "./index.cjs"
+  },
   "scripts": {
-    "test": "nyc --all mocha --exit"
+    "test": "nyc --all mocha --exit",
+    "cjs-compat": "npx rollup index.js --file index.cjs --format cjs",
+    "postinstall": "npm run cjs-compat"
   },
   "repository": {
     "type": "git",
@@ -33,6 +39,7 @@
     "mocha": "^10.2.0",
     "nyc": "^15.1.0",
     "prettier": "^3.0.3",
+    "rollup": "^4.28.1",
     "sinon": "^16.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assertion-tools",
-  "version": "8.0.0-gamma.1",
+  "version": "8.0.0-gamma.2",
   "description": "Common assertion tools used in ot-node and dkg.js",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
Introduce postinstall script that will transpile index.js to index.cjs using simple rollup command. Package rollup added to dev dependencies. Package json configured to support both esm and cjs, using different files for different import methods.

Bumped up version